### PR TITLE
Add grep option

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ Options:
   -d --delay=<s>      Delay between test cycles, in seconds       [default: 0]
   -M --min-time=<s>   Minimum run time per test cycle, in seconds [default: 0]
   -m --max-time=<s>   Maximum run time per test cycle, in seconds [default: 5]
+  -g --grep=<s>       only run suites matching pattern
 ```
 
 ### Suites + benchmarks

--- a/lib/docopt.txt
+++ b/lib/docopt.txt
@@ -10,3 +10,4 @@ Options:
   -d --delay=<s>      Delay between test cycles, in seconds       [default: 0]
   -M --min-time=<s>   Minimum run time per test cycle, in seconds [default: 0]
   -m --max-time=<s>   Maximum run time per test cycle, in seconds [default: 5]
+  -g --grep=<s>       only run suites matching pattern

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -51,6 +51,12 @@ Runner.prototype._run = function(file) {
     if (suite === undefined) {
       return runner._run(runner.files.shift());
     }
+    if (runner.options['--grep']) {
+      var re = new RegExp(runner.options['--grep'], 'i')
+      if (!re.test(suite.name)) {
+        return runSuite(runner.suites.shift());
+      }
+    }
     suite.run({ async : true }).on('complete', function() {
       return runSuite(runner.suites.shift());
     });


### PR DESCRIPTION
Hi! I like your project. I've been manually writing files using benchmark.js, and that's been getting ridiculous; this is a nice way to make that easier.

This adds a `--grep` option, for only running certain benchmark suites. :-)